### PR TITLE
Add remaining database tables and endpoints

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,14 @@
 from fastapi import Depends, FastAPI
 from sqlalchemy.orm import Session
 
+from . import models, schemas
 from .database import Base, SessionLocal, engine
 
 app = FastAPI(title="Somoim API")
 
 # Create database tables
 Base.metadata.create_all(bind=engine)
+
 
 def get_db():
     db = SessionLocal()
@@ -15,6 +17,117 @@ def get_db():
     finally:
         db.close()
 
+
 @app.get("/health")
 def health_check(db: Session = Depends(get_db)):
     return {"status": "ok"}
+
+
+@app.post("/users", response_model=schemas.User)
+def create_user(user: schemas.UserCreate, db: Session = Depends(get_db)):
+    db_user = models.User(
+        email=user.email,
+        nickname=user.nickname,
+        password_hash=user.password,
+    )
+    db.add(db_user)
+    db.commit()
+    db.refresh(db_user)
+    return db_user
+
+
+@app.post("/groups", response_model=schemas.Group)
+def create_group(group: schemas.GroupCreate, db: Session = Depends(get_db)):
+    db_group = models.Group(
+        name=group.name,
+        description=group.description,
+        owner_id=group.owner_id,
+    )
+    db.add(db_group)
+    db.commit()
+    db.refresh(db_group)
+    return db_group
+
+
+@app.post("/groups/{group_id}/members")
+def add_group_member(
+    group_id: int, membership: schemas.MembershipCreate, db: Session = Depends(get_db)
+):
+    member = models.GroupMember(
+        user_id=membership.user_id, group_id=group_id, role=membership.role
+    )
+    db.add(member)
+    db.commit()
+    return {"status": "member added"}
+
+
+@app.post("/groups/{group_id}/posts", response_model=schemas.Post)
+def create_post(group_id: int, post: schemas.PostCreate, db: Session = Depends(get_db)):
+    db_post = models.Post(
+        group_id=group_id,
+        author_id=post.author_id,
+        title=post.title,
+        content=post.content,
+    )
+    db.add(db_post)
+    db.commit()
+    db.refresh(db_post)
+    return db_post
+
+
+@app.post("/posts/{post_id}/comments", response_model=schemas.Comment)
+def create_comment(
+    post_id: int, comment: schemas.CommentCreate, db: Session = Depends(get_db)
+):
+    db_comment = models.Comment(
+        post_id=post_id, author_id=comment.author_id, content=comment.content
+    )
+    db.add(db_comment)
+    db.commit()
+    db.refresh(db_comment)
+    return db_comment
+
+
+@app.post("/groups/{group_id}/events", response_model=schemas.Event)
+def create_event(
+    group_id: int, event: schemas.EventCreate, db: Session = Depends(get_db)
+):
+    db_event = models.Event(
+        group_id=group_id,
+        title=event.title,
+        description=event.description,
+        location=event.location,
+        start_time=event.start_time,
+        end_time=event.end_time,
+    )
+    db.add(db_event)
+    db.commit()
+    db.refresh(db_event)
+    return db_event
+
+
+@app.post("/events/{event_id}/participants")
+def add_event_participant(
+    event_id: int,
+    participant: schemas.EventParticipantCreate,
+    db: Session = Depends(get_db),
+):
+    db_part = models.EventParticipant(
+        event_id=event_id, user_id=participant.user_id, status=participant.status
+    )
+    db.add(db_part)
+    db.commit()
+    return {"status": "participant added"}
+
+
+@app.post("/users/{user_id}/notifications", response_model=schemas.Notification)
+def create_notification(
+    user_id: int, notification: schemas.NotificationCreate, db: Session = Depends(get_db)
+):
+    db_notif = models.Notification(
+        user_id=user_id, type=notification.type, data=notification.data
+    )
+    db.add(db_notif)
+    db.commit()
+    db.refresh(db_notif)
+    return db_notif

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,122 @@
+from datetime import datetime
+
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy.orm import relationship
+
+from .database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True, index=True)
+    email = Column(String, unique=True, index=True, nullable=False)
+    password_hash = Column(String, nullable=False)
+    nickname = Column(String, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    groups = relationship("Group", back_populates="owner")
+    memberships = relationship("GroupMember", back_populates="user")
+    posts = relationship("Post", back_populates="author")
+    comments = relationship("Comment", back_populates="author")
+    event_participations = relationship("EventParticipant", back_populates="user")
+    notifications = relationship("Notification", back_populates="user")
+
+
+class Group(Base):
+    __tablename__ = "groups"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    description = Column(Text)
+    owner_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    owner = relationship("User", back_populates="groups")
+    members = relationship("GroupMember", back_populates="group")
+    posts = relationship("Post", back_populates="group")
+    events = relationship("Event", back_populates="group")
+
+
+class GroupMember(Base):
+    __tablename__ = "group_members"
+
+    user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)
+    group_id = Column(Integer, ForeignKey("groups.id"), primary_key=True)
+    role = Column(String, default="member")
+    joined_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="memberships")
+    group = relationship("Group", back_populates="members")
+
+
+class Post(Base):
+    __tablename__ = "posts"
+
+    id = Column(Integer, primary_key=True, index=True)
+    group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
+    author_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    title = Column(String, nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    group = relationship("Group", back_populates="posts")
+    author = relationship("User", back_populates="posts")
+    comments = relationship("Comment", back_populates="post")
+
+
+class Comment(Base):
+    __tablename__ = "comments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    post_id = Column(Integer, ForeignKey("posts.id"), nullable=False)
+    author_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    content = Column(Text, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    post = relationship("Post", back_populates="comments")
+    author = relationship("User", back_populates="comments")
+
+
+class Event(Base):
+    __tablename__ = "events"
+
+    id = Column(Integer, primary_key=True, index=True)
+    group_id = Column(Integer, ForeignKey("groups.id"), nullable=False)
+    title = Column(String, nullable=False)
+    description = Column(Text)
+    location = Column(String)
+    start_time = Column(DateTime, nullable=False)
+    end_time = Column(DateTime, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    group = relationship("Group", back_populates="events")
+    participants = relationship("EventParticipant", back_populates="event")
+
+
+class EventParticipant(Base):
+    __tablename__ = "event_participants"
+
+    event_id = Column(Integer, ForeignKey("events.id"), primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id"), primary_key=True)
+    status = Column(String, default="going")
+    joined_at = Column(DateTime, default=datetime.utcnow)
+
+    event = relationship("Event", back_populates="participants")
+    user = relationship("User", back_populates="event_participations")
+
+
+class Notification(Base):
+    __tablename__ = "notifications"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    type = Column(String, nullable=False)
+    data = Column(JSON)
+    is_read = Column(Boolean, default=False)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    user = relationship("User", back_populates="notifications")

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,131 @@
+from datetime import datetime
+from pydantic import BaseModel
+
+
+class UserBase(BaseModel):
+    email: str
+    nickname: str
+
+
+class UserCreate(UserBase):
+    password: str
+
+
+class User(UserBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class GroupBase(BaseModel):
+    name: str
+    description: str | None = None
+
+
+class GroupCreate(GroupBase):
+    owner_id: int
+
+
+class Group(GroupBase):
+    id: int
+    owner_id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class MembershipCreate(BaseModel):
+    user_id: int
+    role: str = "member"
+
+
+class PostBase(BaseModel):
+    title: str
+    content: str
+
+
+class PostCreate(PostBase):
+    author_id: int
+
+
+class Post(PostBase):
+    id: int
+    group_id: int
+    author_id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class CommentCreate(BaseModel):
+    author_id: int
+    content: str
+
+
+class Comment(BaseModel):
+    id: int
+    post_id: int
+    author_id: int
+    content: str
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class EventBase(BaseModel):
+    title: str
+    description: str | None = None
+    location: str | None = None
+    start_time: datetime
+    end_time: datetime
+
+
+class EventCreate(EventBase):
+    pass
+
+
+class Event(EventBase):
+    id: int
+    group_id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class EventParticipantCreate(BaseModel):
+    user_id: int
+    status: str = "going"
+
+
+class EventParticipant(BaseModel):
+    event_id: int
+    user_id: int
+    status: str
+    joined_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class NotificationCreate(BaseModel):
+    type: str
+    data: dict | None = None
+
+
+class Notification(BaseModel):
+    id: int
+    user_id: int
+    type: str
+    data: dict | None = None
+    is_read: bool
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+

--- a/docs/db_schema.md
+++ b/docs/db_schema.md
@@ -1,0 +1,67 @@
+# Database Schema
+
+This document outlines the core database tables used by the Somoim application.
+
+## users
+- `id` (PK)
+- `email` (unique)
+- `password_hash`
+- `nickname`
+- `created_at`
+- `updated_at`
+
+## groups
+- `id` (PK)
+- `name`
+- `description`
+- `owner_id` (FK -> users.id)
+- `created_at`
+- `updated_at`
+
+## group_members
+- `user_id` (FK -> users.id)
+- `group_id` (FK -> groups.id)
+- `role`
+- `joined_at`
+- Composite PK (`user_id`, `group_id`)
+
+## posts
+- `id` (PK)
+- `group_id` (FK -> groups.id)
+- `author_id` (FK -> users.id)
+- `title`
+- `content`
+- `created_at`
+- `updated_at`
+
+## comments
+- `id` (PK)
+- `post_id` (FK -> posts.id)
+- `author_id` (FK -> users.id)
+- `content`
+- `created_at`
+
+## events
+- `id` (PK)
+- `group_id` (FK -> groups.id)
+- `title`
+- `description`
+- `location`
+- `start_time`
+- `end_time`
+- `created_at`
+
+## event_participants
+- `event_id` (FK -> events.id)
+- `user_id` (FK -> users.id)
+- `status`
+- `joined_at`
+- Composite PK (`event_id`, `user_id`)
+
+## notifications
+- `id` (PK)
+- `user_id` (FK -> users.id)
+- `type`
+- `data` (JSON)
+- `is_read`
+- `created_at`


### PR DESCRIPTION
## Summary
- document full schema for posts, comments, events, participants, and notifications
- implement SQLAlchemy models and Pydantic schemas for new tables
- add FastAPI endpoints to create posts, comments, events, event participation, and notifications

## Testing
- `pip install -r backend/requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bfcb937778832e93e67395727cf5f0